### PR TITLE
Flexible, Ridiculously Simple Chore Scheduling

### DIFF
--- a/Automation.csproj
+++ b/Automation.csproj
@@ -112,10 +112,12 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AutomationBootstrapper.cs" />
+    <Compile Include="Models\Chore.cs" />
     <Compile Include="Models\Error.cs" />
     <Compile Include="Models\Garage.cs" />
     <Compile Include="Models\GroupMe.cs" />
     <Compile Include="Models\HVAC.cs" />
+    <Compile Include="Modules\ChoreModule.cs" />
     <Compile Include="Modules\GarageModule.cs" />
     <Compile Include="Hubs\HVAC.cs" />
     <Compile Include="Modules\GroupMeModule.cs" />

--- a/Models/Chore.cs
+++ b/Models/Chore.cs
@@ -9,6 +9,8 @@ namespace Automation.Models
     {
         public string Name { get; set; }
         public string Description { get; set; }
+
+        public User User { get; set; }
     }
 
     public class ChoreGroup
@@ -19,6 +21,6 @@ namespace Automation.Models
         public DateTime CurrentRecurrenceStart { get; set; }
         public DateTime CurrentRecurrenceEnd { get; set; }
 
-        public Dictionary<Chore, User> Chores { get; set; }
+        public List<Chore> Chores { get; set; }
     }
 }

--- a/Models/Chore.cs
+++ b/Models/Chore.cs
@@ -16,6 +16,8 @@ namespace Automation.Models
         public string Name { get; set; }
         public DateTime StartDate { get; set; }
         public DateTime EndDate { get; set; }
+        public DateTime CurrentRecurrenceStart { get; set; }
+        public DateTime CurrentRecurrenceEnd { get; set; }
 
         public Dictionary<Chore, User> Chores { get; set; }
     }

--- a/Models/Chore.cs
+++ b/Models/Chore.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace Automation.Models
+{
+    public class Chore
+    {
+        public string Name { get; set; }
+        public string Description { get; set; }
+    }
+
+    public class ChoreGroup
+    {
+        public string Name { get; set; }
+        public DateTime StartDate { get; set; }
+        public DateTime EndDate { get; set; }
+
+        public Dictionary<Chore, User> Chores { get; set; }
+    }
+}

--- a/Models/User.cs
+++ b/Models/User.cs
@@ -15,6 +15,8 @@ namespace Automation
 
         public string UserName { get; set; }
 
+        public int GroupMeId { get; set; }
+
         public IEnumerable<string> Claims { get; set; }
     }
 }

--- a/Models/User.cs
+++ b/Models/User.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Web;
+using System.Xml.Serialization;
 
 namespace Automation
 {
@@ -17,6 +18,7 @@ namespace Automation
 
         public int GroupMeId { get; set; }
 
+        [XmlIgnoreAttribute]
         public IEnumerable<string> Claims { get; set; }
     }
 }

--- a/Modules/ChoreModule.cs
+++ b/Modules/ChoreModule.cs
@@ -113,7 +113,7 @@ namespace Automation.Modules
                                     currentUserIndex = 0;
                                 }
 
-                                if (choreDate < date)
+                                if (choreDate <= date)
                                 {
                                     lastRecurrence = choreDate;
                                 }

--- a/Modules/ChoreModule.cs
+++ b/Modules/ChoreModule.cs
@@ -83,7 +83,7 @@ namespace Automation.Modules
                                 SELECT [User].UserName, [User].GroupMeId FROM [User]
                                 JOIN ChoreGroupUser CGU ON CGU.UserId = [User].Id
                                 WHERE CGU.GroupId = @groupid
-                                ORDER BY [User].Id ASC";
+                                ORDER BY [User].UserName ASC";
                             choreUsers.Parameters.AddWithValue("groupid", choreGroupsReader.GetInt32(0));
 
                             var users = new List<User>();
@@ -102,7 +102,7 @@ namespace Automation.Modules
 
                             var choreRecurrence = new ChoreRecurrence(choreGroup.StartDate, choreGroupsReader.GetString(4), choreGroupsReader.GetInt32(5));
 
-                            var currentUserIndex = 0;
+                            var currentUserIndex = -1;
                             var lastRecurrence = choreGroup.StartDate;
                             foreach (var choreDate in choreRecurrence)
                             {

--- a/Modules/ChoreModule.cs
+++ b/Modules/ChoreModule.cs
@@ -37,7 +37,7 @@ namespace Automation.Modules
                 var queryChoreGroups = choreGroupSql.CreateCommand();
                 queryChoreGroups.CommandText = @"
                     SELECT Id, Name, StartDate, EndDate, RecurrenceDatePart, RecurrenceCount FROM ChoreGroup
-                    WHERE StartDate < @datearg
+                    WHERE StartDate <= @datearg
                     AND (EndDate IS NULL OR (EndDate < @datearg))
                     AND (SELECT COUNT(1) FROM ChoreGroupUser CGU WHERE CGU.GroupId = ChoreGroup.Id) > 0";
                 queryChoreGroups.Parameters.AddWithValue("datearg", date);

--- a/Modules/ChoreModule.cs
+++ b/Modules/ChoreModule.cs
@@ -1,0 +1,136 @@
+﻿using Automation.Models;
+using Nancy;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace Automation.Modules
+{
+    public class ChoreModule : NancyModule
+    {
+        public ChoreModule()
+        {
+            var recurrenceTest = new ChoreRecurrence(DateTime.Now, "day", 7);
+            foreach (var date in recurrenceTest)
+            {
+                Console.WriteLine(date.ToShortDateString());
+                System.Diagnostics.Debugger.Break();
+            }
+        }
+
+        public List<ChoreGroup> GetChoresForDate(DateTime date)
+        {
+            var result = new List<ChoreGroup>();
+
+
+            return result;
+        }
+        
+        public class ChoreRecurrence : IEnumerable<DateTime>, IEnumerator<DateTime>
+        {
+            private DateTime startDate;
+            private string recurrence;
+            private int recurrenceCount;
+
+            public ChoreRecurrence(DateTime startDate, string recurrence, int recurrenceCount)
+            {
+                this.startDate = startDate;
+                this.recurrence = recurrence;
+                this.recurrenceCount = recurrenceCount;
+            }
+
+            private DateTime currentDateTime = DateTime.MinValue;
+
+            public bool MoveNext()
+            {
+                // IEnumerator specifies that we start before the first element in the collection
+                if (currentDateTime == DateTime.MinValue)
+                {
+                    currentDateTime = startDate;
+                }
+                else
+                {
+                    switch (recurrence)
+                    {
+                        case "year":
+                            currentDateTime = currentDateTime.AddYears(1 * recurrenceCount);
+                            break;
+                        case "quarter":
+                            currentDateTime = currentDateTime.AddMonths(3 * recurrenceCount);
+                            break;
+                        case "month":
+                            currentDateTime = currentDateTime.AddMonths(1 * recurrenceCount);
+                            break;
+                        case "dayofyear":
+                            currentDateTime = currentDateTime.AddDays(1 * recurrenceCount);
+                            break;
+                        case "day":
+                            currentDateTime = currentDateTime.AddDays(1 * recurrenceCount);
+                            break;
+                        case "week":
+                            currentDateTime = currentDateTime.AddDays(7 * recurrenceCount);
+                            break;
+                        case "hour":
+                            currentDateTime = currentDateTime.AddHours(1 * recurrenceCount);
+                            break;
+                        case "minute":
+                            currentDateTime = currentDateTime.AddMinutes(1 * recurrenceCount);
+                            break;
+                        case "second":
+                            currentDateTime = currentDateTime.AddSeconds(1 * recurrenceCount);
+                            break;
+                        case "millisecond":
+                            currentDateTime = currentDateTime.AddMilliseconds(1 * recurrenceCount);
+                            break;
+                        case "microsecond":
+                            throw new NotSupportedException("Sub-millisecond recurrence types are not supported");
+                        case "nanosecond":
+                            throw new NotSupportedException("Sub-millisecond recurrence types are not supported");
+                        default:
+                            throw new NotSupportedException("Recurrence type not recognized");
+                    }
+                }
+                return true;
+            }
+
+            public DateTime Current
+            {
+                get
+                {
+                    return currentDateTime;
+                }
+            }
+
+            object IEnumerator.Current
+            {
+                get
+                {
+                    return Current;
+                }
+            }
+
+            public void Reset()
+            {
+                currentDateTime = DateTime.MinValue;
+            }
+
+            public IEnumerator<DateTime> GetEnumerator()
+            {
+                return this;
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return GetEnumerator();
+            }
+
+            public void Dispose()
+            {
+
+            }
+
+        }
+    }
+}

--- a/Modules/ChoreModule.cs
+++ b/Modules/ChoreModule.cs
@@ -106,13 +106,6 @@ namespace Automation.Modules
                             var lastRecurrence = choreGroup.StartDate;
                             foreach (var choreDate in choreRecurrence)
                             {
-                                // Loop through the user index we use later to start assigning
-                                currentUserIndex++;
-                                if (currentUserIndex >= users.Count)
-                                {
-                                    currentUserIndex = 0;
-                                }
-
                                 if (choreDate <= date)
                                 {
                                     lastRecurrence = choreDate;
@@ -140,6 +133,13 @@ namespace Automation.Modules
                                     choreGroup.CurrentRecurrenceStart = lastRecurrence;
                                     choreGroup.CurrentRecurrenceEnd = choreDate;
                                     break;
+                                }
+
+                                // Loop through the user index we use later to start assigning
+                                currentUserIndex++;
+                                if (currentUserIndex >= users.Count)
+                                {
+                                    currentUserIndex = 0;
                                 }
                             }
                         }


### PR DESCRIPTION
This feature allows for chores to be scheduled in the database, using existing schema for Users. It provides an instance method for calculating the ChoreGroups for a given date and time, assigning Users to Chores fairly and predictably.

It's flexible enough to handle rotating schedules minutes long to years long. There can be more Users than Chores or more Chores than Users and it will rotate fairly, assigning less users to chores or more chores to users respectively. Users can be added or removed to the schedule and it will readjust, although past schedules will be changed (if past schedule lookup after changing is necessary, end the previous chore group and create a new one).

Explanation of terms:

**Chore Group:**
Defines a repeating schedule of chores, demarcated by a start date and an end date. Recurrence is controlled using a "recurrence date part", which matches values used by the [T-SQL DateDiff function](https://msdn.microsoft.com/en-us/library/ms189794.aspx). This recurrence date part is multiplied by a recurrence count.

In other words, a chore group with a recurrence date part of 'day' and a recurrence count of 7 will rotate through assigning users to new chores every 7 days.

**Chore:**
Defines one chore in a repeating chore group. Simply a name and a description. The POCO contains a reference to the user assigned to that chore.

**ChoreGroupUser:**
Defines a membership for a user to a chore group. In the aforementioned 7 day chore group, every 7 days this relationship will define who gets assigned to the chores in the chore group.
